### PR TITLE
Switch api-client-csharp to Speakeasy direct mode (INF-6159)

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -26,7 +26,7 @@ jobs:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       force: ${{ github.event.inputs.force }}
-      mode: pr
+      mode: direct
       set_version: ${{ github.event.inputs.set_version }}
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switches the `api-client-csharp` SDK generation workflow from Speakeasy **PR mode** to **direct mode**, so that a spec change results in a commit directly to `main`, a published NuGet release, and a release tag in a single run — no PR to merge.

## Change

In `.github/workflows/sdk_generation.yaml`:

```diff
   with:
     force: ${{ github.event.inputs.force }}
-    mode: pr
+    mode: direct
     set_version: ${{ github.event.inputs.set_version }}
```

## Publishing prerequisite — confirmed already configured

The issue notes that direct mode only changes *when* publishing runs and reuses existing publishing config + secrets, and to confirm current state before treating this as a one-line change. Publishing is already set up:

- `.speakeasy/workflow.yaml` defines `publish.nuget.apiKey: $nuget_api_key` for the `meitner` target.
- `.github/workflows/sdk_publish.yaml` publishes to NuGet on push to `main` when `.speakeasy/gen.lock` changes, using the `NUGET_API_KEY` secret.
- `.github/workflows/sdk_generation.yaml` already wires `nuget_api_key: ${{ secrets.NUGET_API_KEY }}`.

Because NuGet publishing config + secrets are already present, no additional NuGet/Sonatype/GPG setup is required — this is the intended one-line change.

## Acceptance criteria

- [x] `api-client-csharp` generation runs in direct mode.
- [x] A spec change results in a commit to `main`, a published NuGet release, and a release tag (verified via existing publish workflow + config; will be exercised on next generation run).
- [x] No PR is created by the generation workflow.

Parent: INF-5614
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-6159](https://linear.app/meitner-se/issue/INF-6159/switch-api-client-csharp-to-speakeasy-direct-mode)

<div><a href="https://cursor.com/agents/bc-96efca2f-36d3-48fc-9d1c-a519aa3bc92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96efca2f-36d3-48fc-9d1c-a519aa3bc92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

