### PR TITLE
ci: pin Speakeasy SDK-generation action to v15.60.10 (fix INF-6287/INF-6321)

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -23,7 +23,7 @@ permissions:
       - unlabeled
 jobs:
   generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15.60.10
     with:
       force: ${{ github.event.inputs.force }}
       mode: direct

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -14,7 +14,7 @@ permissions:
   workflow_dispatch: {}
 jobs:
   publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15.60.10
     with:
       target: meitner
     secrets:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Intent

Fixes the `publicapis` `main` CI breakage tracked in INF-6287 / INF-6321. The Speakeasy generation action was referenced via the **moving** major tag `@v15`. When Speakeasy repointed it (`v15.60.7` → `v15.60.8`, [PR #336](https://github.com/speakeasy-api/sdk-generation-action/pull/336) swapping `go-git` for system `git`), it silently broke **direct mode** with:

```
fatal: refusing to fetch into branch 'refs/heads/speakeasy-sdk-regen-<n>' checked out
```

## Change

Pin the reusable-workflow references from `@v15` to the exact tag `@v15.60.10` in:

- `.github/workflows/sdk_generation.yaml` (`workflow-executor.yaml`)
- `.github/workflows/sdk_publish.yaml` (`sdk-publish.yaml`) — pinned for consistency with the durable policy

## Which tag & why

Per the issue's preferred option #1 (pin **forward**, keep later fixes): `v15.60.10` is the latest release and already contains the upstream fix for the regression:

- `#336` (`eadcb572`, in `v15.60.8`) — introduced the go-git → system git change that broke direct mode
- `#338` (`7625cebc`) — **fix**: "fetch existing branch via remote-tracking ref so finalize works on checked-out branch"
- plus internal CI ref pins (`#337`, `#339`, `#340`)

`v15.60.10` resolves to commit `7276a3ae83eafb7fe37630fb1fefea3f2649debd`.

## Policy (durable fix)

Do not track `@v15` or any moving major tag. Pin to an exact patch tag and bump deliberately in a PR. Note this only pins the harness — SDK generation quality is still controlled separately by the `speakeasy_version: latest` input.

## Acceptance criteria

- [x] `sdk_generation.yaml` references an exact Speakeasy action tag, not `@v15`
- [x] Pinned forward to a version (`v15.60.10`) that includes the fetch-regression fix (`#338`)
- [ ] A real Directory API spec change flows through direct mode and publishes without the `refusing to fetch into branch … checked out` failure (to be confirmed via a real spec-change run)

> Note: this covers only the `meitner-se/api-client-csharp` repo. The same change must also be applied to `meitner-se/api-client-python` per INF-6321.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [INF-6321](https://linear.app/meitner-se/issue/INF-6321/pin-speakeasy-sdk-generation-action-to-an-exact-tag-in-both-sdk-repos)

<div><a href="https://cursor.com/agents/bc-1e4c4eeb-3d82-4e9a-86d6-a2d161ed1d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e4c4eeb-3d82-4e9a-86d6-a2d161ed1d6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

